### PR TITLE
Post variant level slugs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   tests:
-    name: "Tests"
+    name: "PHP Tests"
     runs-on: ubuntu-latest
 
     steps:
@@ -44,3 +44,14 @@ jobs:
 
       -   name: Run tests
           run: composer test
+
+  ts:
+    name: TypeScript Validation
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Editor
+        run: npm ci && tsc --noEmit

--- a/app/Data/Objects/ConsoleAPI/Post/PostObject.php
+++ b/app/Data/Objects/ConsoleAPI/Post/PostObject.php
@@ -24,7 +24,7 @@ class PostObject
 
     public bool $is_page;
 
-    public ?string $slug;
+    // public ?string $slug;
 
     public ?string $featured_image_url;
 
@@ -60,7 +60,7 @@ class PostObject
         $this->created_at = $post->created_at->getTimestamp();
         $this->updated_at = $post->updated_at->getTimestamp();
         $this->published_at = $post->published_at?->getTimestamp();
-        $this->slug = $post->slug;
+        // $this->slug = $post->slug;
         $this->is_page = (bool) $post->is_page;
         $this->is_featured = (bool) $post->is_featured;
         $this->featured_image_url = $post->featured_image_url;

--- a/app/Data/Objects/ConsoleAPI/Post/PostObject.php
+++ b/app/Data/Objects/ConsoleAPI/Post/PostObject.php
@@ -60,7 +60,6 @@ class PostObject
         $this->created_at = $post->created_at->getTimestamp();
         $this->updated_at = $post->updated_at->getTimestamp();
         $this->published_at = $post->published_at?->getTimestamp();
-        // $this->slug = $post->slug;
         $this->is_page = (bool) $post->is_page;
         $this->is_featured = (bool) $post->is_featured;
         $this->featured_image_url = $post->featured_image_url;

--- a/app/Data/Objects/ConsoleAPI/Post/PostVariantObject.php
+++ b/app/Data/Objects/ConsoleAPI/Post/PostVariantObject.php
@@ -15,6 +15,8 @@ class PostVariantObject
 
     public int $post_id;
 
+    public ?string $slug;
+
     public PostStatusEnum $status;
 
     public string $url;
@@ -49,6 +51,7 @@ class PostVariantObject
         $this->language_id = $language->id;
         $this->post_id = $post->id;
 
+        $this->slug = $variant->slug;
         $this->status = $variant->status;
         $this->url = PermalinkRepository::getPostPermalink($post, $blog, $language);
         $this->content = $variant->content;

--- a/app/Data/Objects/DataAPI/PostObject.php
+++ b/app/Data/Objects/DataAPI/PostObject.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace App\Data\Objects\DataAPI;
 
@@ -73,21 +73,20 @@ class PostObject
         $variant = $variants->firstWhere('language_id', $language->id);
 
         $this->id = $post->id;
-        $this->created_at = $post->created_at->timestamp;
-        $this->updated_at = $variant->updated_at->timestamp;
-        $this->published_at = $post->published_at?->timestamp;
+        $this->created_at = $post->created_at->getTimestamp();
+        $this->updated_at = $variant->updated_at->getTimestamp();
+        $this->published_at = $post->published_at?->getTimestamp();
 
         $this->is_featured = $post->is_featured;
         $this->is_page = $post->is_page;
 
-        // In Preview, slug can be null
-        $this->slug = $post->slug ?? '';
+        $this->slug = $variant->slug ?? '';
 
         $this->url = PermalinkRepository::getPostPermalink($post, $blog, $language);
         $this->content = $variant->content_html ?? '';
         $this->words = $variant->words ?? 0;
-        $this->title = $variant->title;
-        $this->description = $variant->description;
+        $this->title = $variant->title ?? null;
+        $this->description = $variant->description ?? null;
         $this->featured_image_url = $post->featured_image_url;
         $this->canonical_url = $post->canonical_url;
 

--- a/app/Domains/Blog/Fillers/PostFiller.php
+++ b/app/Domains/Blog/Fillers/PostFiller.php
@@ -1,10 +1,12 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace App\Domains\Blog\Fillers;
 
 use App\Data\Enums\BlogTypeEnum;
+use App\Data\Enums\PostStatusEnum;
 use App\Domains\Post\Content\PostContentRepository;
 use App\Domains\Post\PostRepository;
+use App\Exceptions\SafetyException;
 use App\Models\Blog;
 use App\Models\Post;
 use App\Models\PostAuthor;
@@ -13,6 +15,10 @@ use App\Models\PostVariant;
 
 class PostFiller implements FillerInterface
 {
+
+    /**
+     * @var array<array<string, string>>
+     */
     private array $data = [
 
         // posts
@@ -57,32 +63,41 @@ class PostFiller implements FillerInterface
     {
     }
 
-    public function fill()
+    public function fill() : void
     {
         $language = $this->blog->languages[0];
+
+        if (!$language) {
+            throw new SafetyException;
+        }
 
         foreach ($this->data as $row) {
             $isPage = $row['type'] === 'page';
             $post = PostRepository::createPost($this->blog, $isPage);
 
-            $content = file_get_contents(resource_path("posts/{$row['file']}"));
+            $content = strval(file_get_contents(resource_path("posts/{$row['file']}")));
             $content = PostContentRepository::getJsonFromHtml($content, $this->blog);
 
             PostRepository::updatePost($post, [
-                'slug' => $row['slug'],
-                'published_at' => now()->timestamp,
+                'published_at' => now()->getTimestamp(),
             ]);
 
             PostRepository::updatePostVariant($post, $language, [
-                'status' => 'published',
+                'slug' => $row['slug'],
+                'status' => PostStatusEnum::PUBLISHED,
                 'content' => $content,
                 'title' => $row['title'],
                 'description' => $row['description'] ?? '',
             ]);
 
             if (! $isPage) {
-                PostTag::create(['post_id' => $post->id, 'tag_id' => $this->blog->tags[0]->id]);
-                PostAuthor::create(['post_id' => $post->id, 'user_id' => $this->blog->users[0]->id]);
+
+                if ($this->blog->tags[0])
+                    PostTag::create(['post_id' => $post->id, 'tag_id' => $this->blog->tags[0]->id]);
+
+                if ($this->blog->users[0])
+                    PostAuthor::create(['post_id' => $post->id, 'user_id' => $this->blog->users[0]->id]);
+
             }
         }
 

--- a/app/Domains/Delivery/Processors/Sitemap/UrlEntry.php
+++ b/app/Domains/Delivery/Processors/Sitemap/UrlEntry.php
@@ -50,9 +50,11 @@ class UrlEntry
             $imagesXML .= "<image:image><image:loc>$image</image:loc></image:image>\n";
         }
 
+        $loc = htmlspecialchars($this->loc);
+
         return <<<XML
         <url>
-            <loc>$this->loc</loc>
+            <loc>$loc</loc>
             $langAltsXML
             $imagesXML
         </url>

--- a/app/Domains/Delivery/TemplateRenderer/TemplateRenderer.php
+++ b/app/Domains/Delivery/TemplateRenderer/TemplateRenderer.php
@@ -318,8 +318,9 @@ class TemplateRenderer
 
             return $model !== null ? $model : false;
         } elseif ($this->matchedRoute->name === 'post' || $this->matchedRoute->name === 'page') {
-            $post = PostRepository::getPostByBlogIdAndSlug(
-                $this->pathMatcher->blog->id,
+
+            $post = PostRepository::getPostByLanguageAndSlug(
+                $this->pathMatcher->language,
                 $slug
             );
 

--- a/app/Domains/Post/PostRepository.php
+++ b/app/Domains/Post/PostRepository.php
@@ -2,6 +2,7 @@
 
 namespace App\Domains\Post;
 
+use App\Data\Enums\PostStatusEnum;
 use App\Domains\Language\LanguageRepository;
 use App\Domains\Post\Events\PostCreatedEvent;
 use App\Domains\Post\Events\PostDeletedEvent;
@@ -44,6 +45,18 @@ class PostRepository
         return Post::where('blog_id', $blogId)
             ->where('slug', $slug)
             ->first();
+    }
+
+    public static function getPostByLanguageAndSlug(Language $language, string $slug): ?Post
+    {
+        $variant = PostVariant::where('language_id', $language->id)
+            ->where('slug', $slug)
+            ->first();
+
+        if (!$variant)
+            return null;
+
+        return $variant->post;
     }
 
     /**
@@ -264,11 +277,19 @@ class PostRepository
         return Post::find($post->id);
     }
 
-    public static function updatePost(Post $post, array $updates)
+    /**
+     * @param array{
+     *     published_at?: int,
+     *     is_featured?: bool,
+     *     featured_image_url?: ?string,
+     *     canonical_url?: ?string,
+     *     code_head?: ?string,
+     *     code_foot?: ?string,
+     * }  $updates
+     */
+    public static function updatePost(Post $post, array $updates) : Post
     {
-        if (array_key_exists('slug', $updates)) {
-            $post->slug = $updates['slug'];
-        }
+
         // published_at
         if (array_key_exists('published_at', $updates)) {
             $post->published_at = Carbon::createFromTimestamp($updates['published_at']);
@@ -316,7 +337,17 @@ class PostRepository
         return PostVariant::find($variant->id);
     }
 
-    public static function updatePostVariant(Post $post, Language $language, array $updates)
+    /**
+     * @param array{
+     *     slug?: string|null,
+     *     status?: PostStatusEnum,
+     *     content?: string | null,
+     *     content_unsaved?: string | null,
+     *     title?: string | null,
+     *     description?: string | null
+     * } $updates
+     */
+    public static function updatePostVariant(Post $post, Language $language, array $updates) : PostVariant
     {
 
         $variant = self::getPostVariantByPostIdAndLanguageId($post->id, $language->id);
@@ -325,21 +356,22 @@ class PostRepository
             throw new TrustedException('Variant not found', TrustedException::ERROR_UNPROCESSABLE);
         }
 
+        if (array_key_exists('slug', $updates)) {
+            $variant->slug = $updates['slug'];
+        }
+
         // status
         if (array_key_exists('status', $updates)) {
             $status = $updates['status'];
             $variant->status = $status;
 
-            if ($status === 'published') {
+            if ($status === PostStatusEnum::PUBLISHED) {
                 $post->published_at = now();
 
-                // set post slug
-                if (
-                    $post->slug === null &&
-                    $language->is_primary
-                ) {
+                // a slug is required if the post is published
+                if ($variant->slug === null) {
                     $title = $variant->title ?? $updates['title'] ?? null;
-                    $post->slug = $title ? Str::slug($title) : Str::random();
+                    $variant->slug = $title ? Str::slug($title) : Str::random();
                 }
 
                 $post->save();
@@ -368,12 +400,12 @@ class PostRepository
 
         // title
         if (array_key_exists('title', $updates)) {
-            $variant->title = mb_substr($updates['title'], 0, 255);
+            $variant->title = mb_substr($updates['title'] ?? '', 0, 255);
         }
 
         // description
         if (array_key_exists('description', $updates)) {
-            $variant->description = mb_substr($updates['description'], 0, 350);
+            $variant->description = mb_substr($updates['description'] ?? '', 0, 350);
         }
 
         $original = new PostVariant((array) $variant->getOriginal());

--- a/app/Domains/Post/PostRepository.php
+++ b/app/Domains/Post/PostRepository.php
@@ -28,25 +28,6 @@ class PostRepository
         return Post::find($postId);
     }
 
-    public static function getPostByBlogIdAndIdentifier(int $blogId, ?int $id, ?string $slug): ?Post
-    {
-        $post = Post::where('blog_id', $blogId);
-        if ($id) {
-            $post->where('id', $id);
-        } else {
-            $post->where('slug', $slug);
-        }
-
-        return $post->first();
-    }
-
-    public static function getPostByBlogIdAndSlug(int $blogId, string $slug): ?Post
-    {
-        return Post::where('blog_id', $blogId)
-            ->where('slug', $slug)
-            ->first();
-    }
-
     public static function getPostByLanguageAndSlug(Language $language, string $slug): ?Post
     {
         $variant = PostVariant::where('language_id', $language->id)
@@ -183,7 +164,7 @@ class PostRepository
                     ->operators('=,!=');
 
                 $keys->add('slug')
-                    ->column('posts.slug')
+                    ->column('post_variants.slug')
                     ->valueType('string|int')
                     ->operators('=,!=');
 

--- a/app/Domains/Post/PostSearchRepository.php
+++ b/app/Domains/Post/PostSearchRepository.php
@@ -116,7 +116,7 @@ class PostSearchRepository
             'title' => $postVariant->title,
             'description' => $postVariant->description,
             'content' => $post->content ? PostContentRepository::getText($postVariant->content, $blog) : '',
-            'slug' => $post->slug,
+            'slug' => $postVariant->slug,
 
             /**
              * Reference and filtering

--- a/app/Domains/Route/PermalinkRepository.php
+++ b/app/Domains/Route/PermalinkRepository.php
@@ -157,7 +157,8 @@ class PermalinkRepository
             return $post->published_at->format(self::DATE_FORMATTERS[$matches[1]]);
         }, $path);
 
-        $path = str_replace('{slug}', $post->slug, $path);
+        $variant = $post->variants->firstWhere('language_id', $language->id);
+        $path = str_replace('{slug}', $variant?->slug ?? '', $path);
 
         if (str_contains($path, '{tag}')) {
             $path = str_replace('{tag}', $post->tags[0]?->slug ?? '', $path);

--- a/app/Http/Controllers/ConsoleAPI/ConsolePostController.php
+++ b/app/Http/Controllers/ConsoleAPI/ConsolePostController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers\ConsoleAPI;
 
+use App\Data\Enums\PostStatusEnum;
 use App\Data\Objects\ConsoleAPI\Post\PostObject;
 use App\Data\Objects\ConsoleAPI\Post\PostVariantObject;
 use App\Domains\Language\LanguageRepository;
@@ -128,7 +129,7 @@ class ConsolePostController extends Controller
     public function updatePost(Request $request, Blog $blog, Post $post) : JsonResponse
     {
         $request->validate([
-            'slug' => 'string|max:255|nullable',
+           // 'slug' => 'string|max:255|nullable',
             'is_featured' => 'boolean',
             'canonical_url' => 'string|max:255|nullable',
             'featured_image_url' => 'string|max:255|nullable',
@@ -139,7 +140,7 @@ class ConsolePostController extends Controller
 
         $postUpdates = [];
         $postUpdatables = [
-            'slug',
+           // 'slug',
             'is_featured',
             'canonical_url',
             'featured_image_url',
@@ -156,12 +157,12 @@ class ConsolePostController extends Controller
 
         if (count($postUpdates) > 0) {
 
-            if (array_key_exists('slug', $postUpdates)) {
+            /*if (array_key_exists('slug', $postUpdates)) {
                 $bySlugPost = PostRepository::getPostByBlogIdAndSlug($blog->id, strval($postUpdates['slug']));
                 if ($bySlugPost && $bySlugPost->id !== $post->id) {
                     throw new TrustedException('Slug has already been taken');
                 }
-            }
+            }*/
 
             PostRepository::updatePost($post, $postUpdates);
         }
@@ -201,6 +202,7 @@ class ConsolePostController extends Controller
     {
         $request->validate([
             'language_id' => 'required|integer',
+            'slug' => 'string|max:255|nullable',
             'status' => 'string|in:draft,published,scheduled',
             'content' => 'string|nullable',
             'content_unsaved' => 'string|nullable',
@@ -211,33 +213,54 @@ class ConsolePostController extends Controller
         $languageId = $request->integer('language_id');
         $language = LanguageRepository::getLanguageById($blog, $languageId);
 
-        if (! $language) {
+        if (!$language) {
             throw new TrustedException('Language not found', TrustedException::ERROR_UNPROCESSABLE);
         }
 
         $variant = PostRepository::getPostVariantByPostIdAndLanguageId($post->id, $languageId);
 
-        if (! $variant) {
+        if (!$variant) {
             throw new TrustedException('Variant not found', TrustedException::ERROR_NOT_FOUND);
         }
 
-        $variantUpdateables = [
-            'status',
-            'content',
-            'content_unsaved',
-            'title',
-            'description',
-        ];
-
         $variantUpdates = [];
 
-        foreach ($variantUpdateables as $updateable) {
-            if ($request->has($updateable)) {
-                $variantUpdates[$updateable] = $request->input($updateable);
-            }
-        }
+        if ($request->has('slug'))
+            $variantUpdates['slug'] = (string)$request->string('slug');
+
+        if ($request->has('status'))
+            $variantUpdates['status'] = PostStatusEnum::from((string)$request->string('status'));
+
+        if ($request->has('content'))
+            $variantUpdates['content'] = $request->input('content') !== null ?
+                (string) $request->string('content') :
+                null;
+
+        if ($request->has('content_unsaved'))
+            $variantUpdates['content_unsaved'] = $request->input('content_unsaved') !== null ?
+                (string) $request->string('content_unsaved') :
+                null;
+
+        if ($request->has('title'))
+            $variantUpdates['title'] = $request->input('title') !== null ?
+                (string) $request->string('title') :
+                null;
+
+        if ($request->has('description'))
+            $variantUpdates['description'] = $request->input('description') !== null ?
+                (string) $request->string('description') :
+                null;
 
         if (count($variantUpdates) > 0) {
+
+            if (array_key_exists('slug', $variantUpdates)) {
+                $bySlugPost = PostRepository::getPostByLanguageAndSlug($language, strval($variantUpdates['slug']));
+
+                if ($bySlugPost && $bySlugPost->id !== $post->id) {
+                    throw new TrustedException('Slug has already been taken');
+                }
+            }
+
             PostRepository::updatePostVariant($post, $language, $variantUpdates);
         }
 

--- a/app/Http/Controllers/DataApi/PostsController.php
+++ b/app/Http/Controllers/DataApi/PostsController.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace App\Http\Controllers\DataApi;
 
@@ -10,6 +10,7 @@ use App\Domains\Post\PostSearchRepository;
 use App\Exceptions\TrustedException;
 use App\Http\Controllers\Controller;
 use App\Models\Blog;
+use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 
 class PostsController extends Controller
@@ -25,7 +26,7 @@ class PostsController extends Controller
         'words' => 'post_variants.words',
     ];
 
-    public function post(Request $request, Blog $blog)
+    public function post(Request $request, Blog $blog) : JsonResponse
     {
         $request->validate([
             'id' => 'int|required_without:slug',
@@ -34,14 +35,22 @@ class PostsController extends Controller
             'keys' => 'string',
         ]);
 
-        $id = $request->input('id');
-        $slug = $request->input('slug');
-        $language = Helper::getLanguage($blog, $request->input('language'));
-        $keys = $request->input('keys');
+        $id = $request->has('id') ? $request->integer('id') : null;
+        $slug = $request->has('slug') ? (string) $request->string('slug') : null;
+        $language = Helper::getLanguage(
+            $blog,
+            $request->has('language') ? (string) $request->string('language') : null
+        );
+        $keys = $request->has('keys') ? (string) $request->string('keys') : null;
 
-        $post = PostRepository::getPostByBlogIdAndIdentifier($blog->id, $id, $slug);
+        $post = null;
+        if ($id) {
+            $post = PostRepository::getPostById($id);
+        } elseif ($slug) {
+            $post = PostRepository::getPostByLanguageAndSlug($language, $slug);
+        }
 
-        if (! $post) {
+        if (!$post) {
             throw new TrustedException('Post not found', TrustedException::ERROR_NOT_FOUND);
         }
 

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -22,6 +22,7 @@ class Post extends Model
     protected $casts = [
         'published_at' => 'datetime',
         'is_page' => 'boolean',
+        'is_featured' => 'boolean',
     ];
 
     /**

--- a/database/factories/PostFactory.php
+++ b/database/factories/PostFactory.php
@@ -1,17 +1,20 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Database\Factories;
 
 use App\Models\Blog;
+use App\Models\Post;
 use Illuminate\Database\Eloquent\Factories\Factory;
-use Illuminate\Support\Str;
 
+/**
+ * @extends Factory<Post>
+ */
 class PostFactory extends Factory
 {
     /**
      * Define the model's default state.
      *
-     * @return array
+     * @return array<mixed>
      */
     public function definition()
     {
@@ -21,7 +24,7 @@ class PostFactory extends Factory
             'is_page' => false,
             'is_featured' => false,
 
-            'slug' => Str::slug($this->faker->text),
+            // 'slug' => Str::slug($this->faker->text),
             'published_at' => $this->faker->dateTime(),
         ];
     }

--- a/database/factories/PostVariantFactory.php
+++ b/database/factories/PostVariantFactory.php
@@ -7,6 +7,7 @@ use App\Models\Language;
 use App\Models\Post;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
 
 class PostVariantFactory extends Factory
 {
@@ -17,6 +18,8 @@ class PostVariantFactory extends Factory
         return [
             'post_id' => Post::factory(),
             'language_id' => Language::factory(),
+
+            'slug' => Str::slug($this->faker->text),
 
             'status' => Arr::random(['draft', 'published', 'scheduled']),
             'content' => $content,

--- a/database/migrations/2021_09_04_174051_create_posts_table.php
+++ b/database/migrations/2021_09_04_174051_create_posts_table.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;

--- a/database/migrations/2021_09_04_174051_create_posts_table.php
+++ b/database/migrations/2021_09_04_174051_create_posts_table.php
@@ -29,13 +29,13 @@ class CreatePostsTable extends Migration
             $table->boolean('is_featured')->default(false);
 
             // data
-            $table->string('slug')->nullable();
+            // $table->string('slug')->nullable();
             $table->string('featured_image_url')->nullable();
             $table->string('canonical_url')->nullable();
             $table->text('code_head')->nullable();
             $table->text('code_foot')->nullable();
 
-            $table->unique(['blog_id', 'slug']);
+            //$table->unique(['blog_id', 'slug']);
 
             $table->index('blog_id');
             $table->index(['blog_id', 'created_at']);

--- a/database/migrations/2021_09_04_191510_create_post_variants_table.php
+++ b/database/migrations/2021_09_04_191510_create_post_variants_table.php
@@ -20,6 +20,8 @@ return new class () extends Migration {
             $table->bigInteger('post_id');
             $table->bigInteger('language_id');
 
+            $table->string('slug')->nullable();
+
             $table->enum('status', ['published', 'draft', 'scheduled'])->default('draft');
 
             $table->mediumText('content')->nullable();
@@ -30,6 +32,8 @@ return new class () extends Migration {
             $table->integer('words')->nullable();
 
             $table->unique(['post_id', 'language_id']);
+            $table->unique(['language_id', 'slug']);
+
             $table->index('post_id');
             $table->index('language_id');
             $table->index('status');

--- a/production/migrations/2023-04-26-post-variants-slug.sql
+++ b/production/migrations/2023-04-26-post-variants-slug.sql
@@ -1,0 +1,7 @@
+# status = pending
+
+# PRE
+ALTER TABLE post_variants ADD COLUMN slug VARCHAR(255) NULL;
+ALTER TABLE post_variants ADD UNIQUE post_variants_language_id_slug_unique (`language_id`, `slug`);
+
+UPDATE post_variants SET slug = (SELECT slug FROM posts WHERE posts.id = post_variants.post_id);

--- a/resources/docs/api-console.md
+++ b/resources/docs/api-console.md
@@ -20,7 +20,7 @@ Console API allows you to do administrative tasks of a blog. This is the same AP
 
 ## Authenticating User {#authenticating-user}
 
-(TODO)
+[To be written]
 
 ## Categories
 
@@ -176,7 +176,6 @@ type Response = Post
 
 ```ts
 type Request = {
-    slug?: string, // max 255 chars
     is_featured?: boolean,
     featured_image_url?: string | null,
     canonical_url?: string | null,
@@ -214,6 +213,7 @@ type Response = PostVariant
 ```ts
 type Request = {
     language_id: number,
+    slug?: string, // max 255 chars
     status?: 'draft' | 'published' | 'scheduled',
     content?: string | null,
     content_unsaved?: string | null,
@@ -439,8 +439,6 @@ interface Post {
     is_featured: boolean,
     is_page: boolean,
 
-    slug: string,
-
     featured_image_url: string | null,
     canonical_url: string | null,
     code_head: string | null,
@@ -458,7 +456,8 @@ interface Post {
 ```ts
 interface PostVariant {
     language_id: number,
-
+  
+    slug: string | null,
     status: 'draft' | 'published' | 'scheduled',
     url: string,
 

--- a/resources/js/console/Posts/Post/PostTop/PostSettings.tsx
+++ b/resources/js/console/Posts/Post/PostTop/PostSettings.tsx
@@ -116,8 +116,8 @@ export default function PostSettings({ id } : PostSettingsProps) {
                         >
                             <input
                                 className="input"
-                                value={post.slug || ''}
-                                onChange={(e) => updatePostValue("slug", e.target.value)}
+                                value={currentVariant.slug || ''}
+                                onChange={(e) => updateCurrentPostVariantValue("slug", e.target.value)}
                                 maxLength={250}
                             />
                         </Setting>

--- a/resources/js/console/types.ts
+++ b/resources/js/console/types.ts
@@ -120,7 +120,7 @@ export type Post = {
     is_featured: boolean;
     is_page: boolean;
 
-    slug: string;
+    // slug: string;
 
     featured_image_url: string | null;
     canonical_url: string | null;
@@ -139,7 +139,7 @@ export type PostStatus = 'draft' | 'published' | 'scheduled'
 export type PostVariant = {
 
     language_id: number;
-
+    slug: string | null,
     status: PostStatus,
     url: string,
 

--- a/tests/Feature/ConsoleAPI/Posts/UpdatePostTest.php
+++ b/tests/Feature/ConsoleAPI/Posts/UpdatePostTest.php
@@ -12,7 +12,7 @@ it('updates a post', function () {
     $blog = blogWithAccess();
     $post = addPost($blog);
 
-    $slug = 'hello-world';
+    // $slug = 'hello-world';
     $isFeatured = true;
     $canonicalUrl = 'https://example.com';
     $featuredImageUrl = 'https://example.com/image.png';
@@ -20,7 +20,7 @@ it('updates a post', function () {
     $codeFoot = 'foot code';
 
     consoleApi($blog, 'PATCH', "/post/$post->id", [
-            'slug' => $slug,
+            //'slug' => $slug,
             'is_featured' => $isFeatured,
             'canonical_url' => $canonicalUrl,
             'featured_image_url' => $featuredImageUrl,
@@ -30,7 +30,7 @@ it('updates a post', function () {
         ->assertOk()
         ->assertJson(
             fn (AssertableJson $json) => $json
-                ->where('slug', $slug)
+                // ->where('slug', $slug)
                 ->where('is_featured', $isFeatured)
                 ->where('canonical_url', $canonicalUrl)
                 ->where('featured_image_url', $featuredImageUrl)
@@ -40,21 +40,4 @@ it('updates a post', function () {
         );
 
     Event::assertDispatched(PostUpdatedEvent::class);
-});
-
-it('checks for duplicates when updating slug', function() {
-
-    $blog = blogWithAccessLanguageAndRoutes();
-    $post = addPost($blog, [
-        'slug' => 'hello-world'
-    ]);
-
-    $post2 = addPost($blog);
-
-    consoleApi($blog, 'PATCH', "/post/$post2->id", [
-            'slug' => 'hello-world',
-    ])
-        ->assertStatus(422)
-        ->assertSee('Slug has already been taken');
-
 });

--- a/tests/Feature/ConsoleAPI/Posts/UpdatePostVariantTest.php
+++ b/tests/Feature/ConsoleAPI/Posts/UpdatePostVariantTest.php
@@ -21,6 +21,7 @@ it('updates post variant', function () {
     $variant = $post->variants[0];
     $language = $variant->language;
 
+    $slug = 'hello-world';
     $status = 'scheduled';
     $content = 'this is content';
     $contentUnsaved = 'this is unsaved content';
@@ -29,6 +30,7 @@ it('updates post variant', function () {
 
     consoleApi($blog, 'PATCH', "/post/$post->id/variant", [
             'language_id' => $language->id,
+            'slug' => $slug,
             'status' => $status,
             'content' => $content,
             'content_unsaved' => $contentUnsaved,
@@ -38,6 +40,7 @@ it('updates post variant', function () {
         ->assertOk()
         ->assertJson(
             fn (AssertableJson $json) => $json
+                ->where('slug', $slug)
                 ->where('status', $status)
                 ->where('content', $content)
                 ->where('content_unsaved', $contentUnsaved)
@@ -83,9 +86,8 @@ it('sets the slug if it is empty when publishing the primary language post', fun
     $post = Post::factory()->create([
         'blog_id' => $blog,
         'published_at' => null,
-        'slug' => null
     ]);
-    PostVariant::factory()->create([
+    $variant = PostVariant::factory()->create([
         'post_id' => $post,
         'language_id' => $blog->languages[0],
         'status' => PostStatusEnum::DRAFT,
@@ -97,7 +99,7 @@ it('sets the slug if it is empty when publishing the primary language post', fun
         ])
         ->assertOk();
 
-    expect($post->refresh()->slug)->not->toBeNull();
+    expect($variant->refresh()->slug)->not->toBeNull();
 
 });
 
@@ -109,9 +111,9 @@ it('updates slug when title is empty', function() {
     $post = Post::factory()->create([
         'blog_id' => $blog,
         'published_at' => null,
-        'slug' => null
+        // 'slug' => null
     ]);
-    PostVariant::factory()->create([
+    $variant = PostVariant::factory()->create([
         'post_id' => $post,
         'language_id' => $blog->languages[0],
         'status' => PostStatusEnum::DRAFT,
@@ -124,7 +126,7 @@ it('updates slug when title is empty', function() {
     ])
         ->assertOk();
 
-    expect($post->refresh()->slug)->not->toBeNull();
+    expect($variant->refresh()->slug)->not->toBeNull();
 
 });
 
@@ -135,7 +137,6 @@ it('creates a history if post content has changed', function() {
     $post = Post::factory()->create([
         'blog_id' => $blog,
         'published_at' => null,
-        'slug' => null
     ]);
     $variant = PostVariant::factory()->create([
         'post_id' => $post,
@@ -163,7 +164,6 @@ it('does not update if the content is the same', function() {
     $post = Post::factory()->create([
         'blog_id' => $blog,
         'published_at' => null,
-        'slug' => null
     ]);
     $variant = PostVariant::factory()->create([
         'post_id' => $post,
@@ -190,7 +190,6 @@ it('deletes old histories', function() {
     $post = Post::factory()->create([
         'blog_id' => $blog,
         'published_at' => null,
-        'slug' => null
     ]);
     $variant = PostVariant::factory()->create([
         'post_id' => $post,
@@ -215,5 +214,27 @@ it('deletes old histories', function() {
     expect($variant->history()->orderBy('id', 'desc')->first()->content)->toBe($para);
 
     expect(PostVariantHistory::count())->toBe(25);
+
+});
+
+it('checks for duplicates when updating slug', function() {
+
+    $blog = blogWithAccessLanguageAndRoutes();
+    $language1 = addLanguage($blog);
+    $post = addPost($blog, [], [
+        'language_id' => $language1->id,
+        'slug' => 'hello-world'
+    ]);
+
+    $post2 = addPost($blog, [], [
+        'language_id' => $language1->id,
+    ]);
+
+    consoleApi($blog, 'PATCH', "/post/$post2->id/variant", [
+        'language_id' => $language1->id,
+        'slug' => 'hello-world',
+    ])
+        ->assertStatus(422)
+        ->assertSee('Slug has already been taken');
 
 });

--- a/tests/Feature/DataApi/PostTest.php
+++ b/tests/Feature/DataApi/PostTest.php
@@ -49,7 +49,7 @@ it('requires an integer id', function () {
 
 it('works with post slug', function () {
     dataApi($this->blog, '/post', [
-            'slug' => $this->post->slug,
+            'slug' => $this->post->variants[0]->slug,
         ])
         ->assertOk()
         ->assertExactJson($this->postObject);

--- a/tests/Feature/DataApi/PostsTest.php
+++ b/tests/Feature/DataApi/PostsTest.php
@@ -294,19 +294,19 @@ it('filters_by_is_featured', function () {
         'filter' => 'is_featured=true',
     ]);
     $response
-        ->assertJsonPath('data.0.slug', $post->slug)
+        ->assertJsonPath('data.0.slug', $post->variants[0]->slug)
         ->assertJsonCount(1, 'data');
 });
 
 it('filters by slug', function () {
     $post = $this->posts->random();
-    $post->update(['slug' => 'some-new-slug']);
+    $post->variants[0]->update(['slug' => 'some-new-slug']);
 
     $response = dataApi($this->blog, '/posts', [
-        'filter' => "slug=$post->slug",
+        'filter' => "slug=some-new-slug",
     ]);
     $response
-        ->assertJsonPath('data.0.slug', $post->slug)
+        ->assertJsonPath('data.0.slug', $post->variants[0]->slug)
         ->assertJsonCount(1, 'data');
 });
 

--- a/tests/Unit/Domains/Blog/Fillers/PostFillerTest.php
+++ b/tests/Unit/Domains/Blog/Fillers/PostFillerTest.php
@@ -22,11 +22,11 @@ it('fills with posts', function () {
     $posts = $blog->posts;
     expect(count($posts))->toBe(5);
 
-    expect($posts->firstWhere('slug', 'welcome'))->toBeInstanceOf(Post::class);
-    expect($posts->firstWhere('slug', 'content-style'))->toBeInstanceOf(Post::class);
-    expect($posts->firstWhere('slug', 'about'))->toBeInstanceOf(Post::class);
-    expect($posts->firstWhere('slug', 'privacy'))->toBeInstanceOf(Post::class);
-    expect($posts->firstWhere('slug', 'contact'))->toBeInstanceOf(Post::class);
+    expect($posts->firstWhere(fn($p) => $p->variants[0]['slug'] === 'welcome'))->toBeInstanceOf(Post::class);
+    expect($posts->firstWhere(fn($p) => $p->variants[0]['slug'] === 'content-style'))->toBeInstanceOf(Post::class);
+    expect($posts->firstWhere(fn($p) => $p->variants[0]['slug'] === 'about'))->toBeInstanceOf(Post::class);
+    expect($posts->firstWhere(fn($p) => $p->variants[0]['slug'] === 'privacy'))->toBeInstanceOf(Post::class);
+    expect($posts->firstWhere(fn($p) => $p->variants[0]['slug'] === 'contact'))->toBeInstanceOf(Post::class);
 
     $post1 = $posts[0];
 

--- a/tests/Unit/Domains/Cache/Listeners/ClearCacheSubscriber/TemplateCacheTest.php
+++ b/tests/Unit/Domains/Cache/Listeners/ClearCacheSubscriber/TemplateCacheTest.php
@@ -146,7 +146,7 @@ it('clears cache when editing a post', function () {
         ]), 'variants')
         ->create(['blog_id' => $blog]);
 
-    $post->slug = 'new-slug';
+    $post->code_head = 'new-code';
 
     $event = new PostUpdatedEvent($post);
     $listener = new ClearCacheSubscriber();
@@ -167,7 +167,7 @@ it('does not clear cache when editing a post if the primary variant is not publi
         ]), 'variants')
         ->create(['blog_id' => $blog]);
 
-    $post->slug = 'new-slug';
+    $post->code_head = 'new-code';
 
     $event = new PostUpdatedEvent($post);
     $listener = new ClearCacheSubscriber();
@@ -181,7 +181,7 @@ it('clears cache when a post is deleted', function () {
 
     $post = Post::factory()->create(['blog_id' => $blog]);
 
-    $post->slug = 'new-slug';
+    $post->code_head = 'new-code';
 
     $event = new PostDeletedEvent($post);
     $listener = new ClearCacheSubscriber();

--- a/tests/Unit/Domains/Delivery/Response/PostTest.php
+++ b/tests/Unit/Domains/Delivery/Response/PostTest.php
@@ -27,7 +27,7 @@ it('matches a post', function () {
         ->where('posts.is_page', false)
         ->where('posts.blog_id', $blog->id)
         ->where('post_variants.language_id', $blog->languages[0]->id)
-        ->select('posts.slug', 'posts.id')
+        ->select(['post_variants..slug', 'posts.id'])
         ->first();
 
     $pathMatcher = new PathMatcher($blog, "/$variant->slug");
@@ -57,7 +57,7 @@ it('matches a page', function () {
         ->where('posts.is_page', true)
         ->where('posts.blog_id', $blog->id)
         ->where('post_variants.language_id', $blog->languages[0]->id)
-        ->select('posts.slug', 'posts.id')
+        ->select(['post_variants.slug', 'posts.id'])
         ->first();
 
     $pathMatcher = new PathMatcher($blog, "/$variant->slug");
@@ -89,7 +89,7 @@ it('matches a post with language', function () {
         ->where('posts.is_page', false)
         ->where('posts.blog_id', $blog->id)
         ->where('post_variants.language_id', $blog->languages[1]->id)
-        ->select('posts.slug', 'posts.id')
+        ->select('post_variants.slug', 'posts.id')
         ->first();
 
     $pathMatcher = new PathMatcher($blog, "/{$blog->languages[1]->code}/$variant->slug");

--- a/tests/Unit/Domains/Delivery/Response/Sitemap/SitemapPagesTest.php
+++ b/tests/Unit/Domains/Delivery/Response/Sitemap/SitemapPagesTest.php
@@ -51,7 +51,7 @@ it('generates entries for pages and its variants', function () {
     $crawler = new Crawler($doc);
 
     expect($crawler->filter('default|loc')->count())->toBe(4); // index + pages
-    expect($crawler->filter('default|loc')->eq(1)->innerText())->toContain($pages[0]->slug);
+    expect($crawler->filter('default|loc')->eq(1)->innerText())->toContain($pages[0]->variants[0]->slug);
 
     // language variants
     expect($crawler->filter('default|url')->eq(2)->filter('xhtml|link')->count())->toBe(1);

--- a/tests/Unit/Domains/Delivery/Response/Sitemap/UrlPostEntryTest.php
+++ b/tests/Unit/Domains/Delivery/Response/Sitemap/UrlPostEntryTest.php
@@ -11,7 +11,9 @@ it('works', function () {
     $blog->refresh();
     $post = addPublishedPost($blog);
     $basePath = PermalinkRepository::getFullUrlFromPath($blog);
-    $slug = $post->slug;
+
+    $slug = $post->variants[0]->slug;
+    $translatedSlug = $post->variants[1]->slug;
 
     $post->variants[0]->update([
         'content' => json_encode([
@@ -50,7 +52,7 @@ it('works', function () {
 
     expect($xml)->toContain("<loc>$basePath/$slug</loc>");
     expect($xml)->toContain("<xhtml:link rel=\"alternate\" hreflang=\"{$blog->languages[0]->code}\" href=\"$basePath/$slug\" />");
-    expect($xml)->toContain("<xhtml:link rel=\"alternate\" hreflang=\"{$blog->languages[1]->code}\" href=\"$basePath/{$blog->languages[1]->code}/$slug\" />");
+    expect($xml)->toContain("<xhtml:link rel=\"alternate\" hreflang=\"{$blog->languages[1]->code}\" href=\"$basePath/{$blog->languages[1]->code}/$translatedSlug\" />");
 
     expect($xml)->toContain("<image:image><image:loc>$basePath/image.png</image:loc></image:image>");
     expect($xml)->toContain("<image:image><image:loc>$basePath/image2.png</image:loc></image:image>");

--- a/tests/Unit/Domains/Delivery/TemplateRendering/Variables/FootTest.php
+++ b/tests/Unit/Domains/Delivery/TemplateRendering/Variables/FootTest.php
@@ -54,7 +54,7 @@ it('sets _foot in a post page', function () {
         $content,
     );
 
-    $pathMatcher = new PathMatcher($blog, "/$post->slug");
+    $pathMatcher = new PathMatcher($blog, "/{$post->variants[0]->slug}");
     $responseObject = $pathMatcher->getResponseObject();
 
     $content = $responseObject->content;

--- a/tests/Unit/Domains/Delivery/TemplateRendering/Variables/HeadTest.php
+++ b/tests/Unit/Domains/Delivery/TemplateRendering/Variables/HeadTest.php
@@ -83,7 +83,7 @@ it('sets _head in a post page', function () {
     // add twitter URL to first author
     $post->authors[0]->update(['social_twitter' => 'https://twitter.com/Author']);
 
-    $pathMatcher = new PathMatcher($blog, "/$post->slug");
+    $pathMatcher = new PathMatcher($blog, "/{$post->variants[0]->slug}");
     $responseObject = $pathMatcher->getResponseObject();
 
     $content = $responseObject->content;
@@ -132,7 +132,7 @@ it('adds nofollow', function () {
         $content,
     );
 
-    $pathMatcher = new PathMatcher($blog, "/$post->slug");
+    $pathMatcher = new PathMatcher($blog, "/{$post->variants[0]->slug}");
     $responseObject = $pathMatcher->getResponseObject();
     $content = $responseObject->content;
 

--- a/tests/Unit/Domains/Delivery/TemplateRendering/Variables/PostsTest.php
+++ b/tests/Unit/Domains/Delivery/TemplateRendering/Variables/PostsTest.php
@@ -27,7 +27,7 @@ it('does not set _posts and _pagination when posts_filter is null in the route',
 
     $post = addPublishedPost($blog);
 
-    $pathMatcher = new PathMatcher($blog, '/'.$post->slug);
+    $pathMatcher = new PathMatcher($blog, '/'.$post->variants[0]->slug);
     $responseObject = $pathMatcher->getResponseObject();
 
     expect($responseObject->content)->toContain('posts variable not defined');


### PR DESCRIPTION
Previously `slug` was saved in `Post`
Now `slug` is saved in `PostVariant`

Which means each translated variant can have its own slug.

Manually test:

- [ ] Slugs are working
- [ ] Duplicate slugs cannot be created for the same language
- [ ] The blog is rendering correctly
- [ ] Language switcher is working

