### PR TITLE
Fix icon display in date picker

### DIFF
--- a/resources/css/console/components/datepicker.scss
+++ b/resources/css/console/components/datepicker.scss
@@ -30,6 +30,9 @@
         &.react-datepicker__navigation--next {
             right:10px;
         }
+        .react-datepicker__navigation-icon::before {
+            border-width: 3px 3px 0 0 !important;
+        }
     }
     .react-datepicker__current-month {
         margin-bottom:10px;


### PR DESCRIPTION
The arrow for changing the month are now displayed
![image](https://user-images.githubusercontent.com/88531865/235079468-5dd906c7-9d4a-4a13-a884-73b66952326d.png)
