### PR TITLE
Link analyzer not running fix

### DIFF
--- a/backend/app/Domains/LinkAnalyzer/Check/AnalyzeAllLinksJob.php
+++ b/backend/app/Domains/LinkAnalyzer/Check/AnalyzeAllLinksJob.php
@@ -28,7 +28,7 @@ class AnalyzeAllLinksJob implements ShouldQueue
     )
     {
         $this->check = LinkAnalyzerCheckService::createCheck($blog);
-        $this->onQueue(AppQueues::reports());
+        // $this->onQueue(AppQueues::reports());
     }
 
     public function handle() : void


### PR DESCRIPTION
Supervisor only runs the default queue. This job was pushed to a different queue after Redis migration.